### PR TITLE
Fix Minecraft Version

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -30,7 +30,7 @@
   "accessWidener": "betterrecipebook.accessWidener",
   "depends": {
     "fabricloader": ">=0.11.3",
-    "minecraft": "1.17.x",
+    "minecraft": "1.18.x",
     "cloth-config2": ">=5.0.38"
   }
 }


### PR DESCRIPTION
The latest released version of BetterRecipeBook (1.5.4) won't launch on 1.18 (snapshot 21w42a) because of mrshmllow@1ec4746. This PR changes the version back to 1.18.