### PR TITLE
Change fabric.mod.json to load the mod only on the client

### DIFF
--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -16,7 +16,7 @@
   },
   "license": "MIT",
   "icon": "assets/brb/icon.png",
-  "environment": "*",
+  "environment": "client",
   "entrypoints": {
     "main": [
       "marsh.town.brb.fabric.BetterRecipeBookFabric"


### PR DESCRIPTION
This mod crashes when running it on a fabric server. If this mod is indeed client only, fabric.mod.json should be changed to reflect that. This trivial change probably doesn't need testing, but I tested it on a client and a server, and it works as intended.