### PR TITLE
Update for 1.19.4

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -9,7 +9,7 @@ dependencies {
 
     modApi "dev.architectury:architectury:${rootProject.architectury_version}"
 
-    modApi("me.shedaniel.cloth:cloth-config-fabric:9.0.94") {
+    modApi("me.shedaniel.cloth:cloth-config-fabric:${rootProject.cloth_config_version}") {
         exclude(group: "net.fabricmc.fabric-api")
     }
 }

--- a/common/src/main/java/marsh/town/brb/BrewingStand/AnimatedResultButton.java
+++ b/common/src/main/java/marsh/town/brb/BrewingStand/AnimatedResultButton.java
@@ -44,7 +44,7 @@ public class AnimatedResultButton extends AbstractWidget {
         this.brewingStandScreenHandler = brewingStandScreenHandler;
     }
 
-    public void renderButton(PoseStack matrices, int mouseX, int mouseY, float delta) {
+    public void renderWidget(PoseStack matrices, int mouseX, int mouseY, float delta) {
         if (!Screen.hasControlDown()) {
             this.time += delta;
         }
@@ -75,8 +75,8 @@ public class AnimatedResultButton extends AbstractWidget {
 
         matrixStack.pushPose();
         matrixStack.mulPoseMatrix(matrices.last().pose()); // No idea what this does
-        minecraftClient.getItemRenderer().renderAndDecorateItem(potionRecipe.ingredient, getX() + k, getY() + k); // Why do we do this twice?
-        minecraftClient.getItemRenderer().renderGuiItemDecorations(Minecraft.getInstance().font, potionRecipe.ingredient, getX() + k, getY() + k); // ^
+        minecraftClient.getItemRenderer().renderAndDecorateItem(matrices, potionRecipe.ingredient, getX() + k, getY() + k); // Why do we do this twice?
+        minecraftClient.getItemRenderer().renderGuiItemDecorations(matrices, Minecraft.getInstance().font, potionRecipe.ingredient, getX() + k, getY() + k); // ^
         RenderSystem.enableDepthTest();
         matrixStack.popPose();
         RenderSystem.applyModelViewMatrix();

--- a/common/src/main/java/marsh/town/brb/BrewingStand/RecipeBookGhostSlots.java
+++ b/common/src/main/java/marsh/town/brb/BrewingStand/RecipeBookGhostSlots.java
@@ -51,12 +51,12 @@ public class RecipeBookGhostSlots {
 
             ItemStack itemStack = ghostInputSlot.getCurrentItemStack();
             ItemRenderer itemRenderer = client.getItemRenderer();
-            itemRenderer.renderAndDecorateFakeItem(itemStack, l, m);
+            itemRenderer.renderAndDecorateFakeItem(matrices, itemStack, l, m);
             RenderSystem.depthFunc(516);
             GuiComponent.fill(matrices, l, m, l + 16, m + 16, 822083583);
             RenderSystem.depthFunc(515);
             if (k == 0) {
-                itemRenderer.renderGuiItemDecorations(client.font, itemStack, l, m);
+                itemRenderer.renderGuiItemDecorations(matrices, client.font, itemStack, l, m);
             }
         }
 

--- a/common/src/main/java/marsh/town/brb/BrewingStand/RecipeBookWidget.java
+++ b/common/src/main/java/marsh/town/brb/BrewingStand/RecipeBookWidget.java
@@ -319,7 +319,7 @@ public class RecipeBookWidget extends AbstractWidget implements GuiEventListener
     }
 
     @Override
-    public void render(PoseStack matrices, int mouseX, int mouseY, float delta) {
+    public void renderWidget(PoseStack matrices, int mouseX, int mouseY, float delta) {
         if (this.searchField == null) return;
 
         if (doubleRefresh) {
@@ -467,7 +467,7 @@ public class RecipeBookWidget extends AbstractWidget implements GuiEventListener
                     return false;
                 } else if (this.client.options.keyChat.matches(keyCode, scanCode) && !this.searchField.isFocused()) {
                     this.searching = true;
-                    this.searchField.setFocus(true);
+                    this.searchField.setFocused(true);
                     return true;
                 } else {
                     return false;

--- a/common/src/main/java/marsh/town/brb/BrewingStand/RecipeGroupButtonWidget.java
+++ b/common/src/main/java/marsh/town/brb/BrewingStand/RecipeGroupButtonWidget.java
@@ -22,7 +22,7 @@ public class RecipeGroupButtonWidget extends StateSwitchingButton {
         this.initTextureValues(153, 2, 35, 0, RecipeBookWidget.TEXTURE);
     }
 
-    public void renderButton(PoseStack matrices, int mouseX, int mouseY, float delta) {
+    public void renderWidget(PoseStack matrices, int mouseX, int mouseY, float delta) {
         Minecraft minecraftClient = Minecraft.getInstance();
         RenderSystem.setShader(GameRenderer::getPositionTexShader);
         RenderSystem.setShaderTexture(0, this.resourceLocation);
@@ -45,17 +45,17 @@ public class RecipeGroupButtonWidget extends StateSwitchingButton {
         RenderSystem.setShaderColor(1.0F, 1.0F, 1.0F, 1.0F);
         this.blit(matrices, k, getY(), i, j, this.width, this.height);
         RenderSystem.enableDepthTest();
-        this.renderIcons(minecraftClient.getItemRenderer());
+        this.renderIcons(matrices, minecraftClient.getItemRenderer());
     }
 
-    private void renderIcons(ItemRenderer itemRenderer) {
+    private void renderIcons(PoseStack matrices, ItemRenderer itemRenderer) {
         List<ItemStack> list = this.group.getIcons();
         int i = this.isStateTriggered ? -2 : 0;
         if (list.size() == 1) {
-            itemRenderer.renderAndDecorateFakeItem(list.get(0), getX() + 9 + i, getY() + 5);
+            itemRenderer.renderAndDecorateFakeItem(matrices, list.get(0), getX() + 9 + i, getY() + 5);
         } else if (list.size() == 2) {
-            itemRenderer.renderAndDecorateFakeItem(list.get(0), getX() + 3 + i, getY() + 5);
-            itemRenderer.renderAndDecorateFakeItem(list.get(1), getX() + 14 + i, getY() + 5);
+            itemRenderer.renderAndDecorateFakeItem(matrices, list.get(0), getX() + 3 + i, getY() + 5);
+            itemRenderer.renderAndDecorateFakeItem(matrices, list.get(1), getX() + 14 + i, getY() + 5);
         }
 
     }

--- a/common/src/main/java/marsh/town/brb/InstantCraftingManager.java
+++ b/common/src/main/java/marsh/town/brb/InstantCraftingManager.java
@@ -2,6 +2,7 @@ package marsh.town.brb;
 
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
+import net.minecraft.core.RegistryAccess;
 import net.minecraft.world.inventory.ClickType;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
@@ -16,9 +17,9 @@ public class InstantCraftingManager {
         this.on = false;
     }
 
-    public void recipeClicked(Recipe<?> recipe) {
+    public void recipeClicked(Recipe<?> recipe, RegistryAccess registryAccess) {
         if (BetterRecipeBook.instantCraftingManager.on) {
-            lastCraft = recipe.getResultItem();
+            lastCraft = recipe.getResultItem(registryAccess);
         }
     }
 

--- a/common/src/main/java/marsh/town/brb/Mixins/AlternativeRecipes.java
+++ b/common/src/main/java/marsh/town/brb/Mixins/AlternativeRecipes.java
@@ -31,15 +31,16 @@ public abstract class AlternativeRecipes extends AbstractWidget implements Place
     private boolean isCraftable;
     @Final @Shadow
     Recipe<?> recipe;
-    @Shadow public abstract void renderButton(PoseStack matrices, int mouseX, int mouseY, float delta);
+    @Shadow public abstract void renderWidget(PoseStack matrices, int mouseX, int mouseY, float delta);
     @Shadow @Final protected List<OverlayRecipeComponent.OverlayRecipeButton.Pos> ingredientPos;
+    @Shadow @Final OverlayRecipeComponent field_3113;
 
     public AlternativeRecipes(int x, int y, int width, int height, Component message) {
         super(x, y, width, height, message);
     }
 
-    @Inject(at = @At("HEAD"), method = "renderButton", cancellable = true)
-    public void renderButton(PoseStack matrices, int mouseX, int mouseY, float delta, CallbackInfo ci) {
+    @Inject(at = @At("HEAD"), method = "renderWidget", cancellable = true)
+    public void renderWidget(PoseStack matrices, int mouseX, int mouseY, float delta, CallbackInfo ci) {
         RenderSystem.setShaderTexture(0, BACKGROUND_TEXTURE);
         int i = 0;
         int j = 0;
@@ -59,7 +60,7 @@ public abstract class AlternativeRecipes extends AbstractWidget implements Place
 
             matrixStack.pushPose();
             matrixStack.mulPoseMatrix(matrices.last().pose()); // No idea what this does
-            Minecraft.getInstance().getItemRenderer().renderAndDecorateItem(this.ingredientPos.get(0).ingredients[0], getX() + 4, getY() + 4);
+            Minecraft.getInstance().getItemRenderer().renderAndDecorateItem(matrices, this.ingredientPos.get(0).ingredients[0], getX() + 4, getY() + 4);
             RenderSystem.enableDepthTest();
             matrixStack.popPose();
             RenderSystem.applyModelViewMatrix();
@@ -71,13 +72,13 @@ public abstract class AlternativeRecipes extends AbstractWidget implements Place
             this.blit(matrices, getX(), getY(), i, j, this.width, this.height);
 
             ItemRenderer itemRenderer = Minecraft.getInstance().getItemRenderer();
-            ItemStack recipeOutput = this.recipe.getResultItem();
+            ItemStack recipeOutput = this.recipe.getResultItem(field_3113.getRecipeCollection().registryAccess());
 
             PoseStack matrixStack = RenderSystem.getModelViewStack();
 
             matrixStack.pushPose();
             matrixStack.mulPoseMatrix(matrices.last().pose()); // No idea what this does
-            itemRenderer.renderAndDecorateItem(recipeOutput, getX() + 4, getY() + 4);
+            itemRenderer.renderAndDecorateItem(matrices, recipeOutput, getX() + 4, getY() + 4);
             RenderSystem.enableDepthTest();
             matrixStack.popPose();
             RenderSystem.applyModelViewMatrix();

--- a/common/src/main/java/marsh/town/brb/Mixins/InstantCraft/ClientPlayerInteractionManagerMixin.java
+++ b/common/src/main/java/marsh/town/brb/Mixins/InstantCraft/ClientPlayerInteractionManagerMixin.java
@@ -1,17 +1,23 @@
 package marsh.town.brb.Mixins.InstantCraft;
 
 import marsh.town.brb.BetterRecipeBook;
+import net.minecraft.client.Minecraft;
 import net.minecraft.client.multiplayer.MultiPlayerGameMode;
 import net.minecraft.world.item.crafting.Recipe;
+import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(MultiPlayerGameMode.class)
 public class ClientPlayerInteractionManagerMixin {
+    @Shadow @Final private Minecraft minecraft;
+
     @Inject(method = "handlePlaceRecipe", at = @At("TAIL"))
     private void handlePlaceRecipe(int syncId, Recipe<?> recipe, boolean craftAll, CallbackInfo ci) {
-        BetterRecipeBook.instantCraftingManager.recipeClicked(recipe);
+        assert minecraft.level != null;
+        BetterRecipeBook.instantCraftingManager.recipeClicked(recipe, minecraft.level.registryAccess());
     }
 }

--- a/common/src/main/java/marsh/town/brb/Mixins/Pins/Icon.java
+++ b/common/src/main/java/marsh/town/brb/Mixins/Pins/Icon.java
@@ -15,19 +15,19 @@ public class Icon {
 
     @Shadow private float animationTime;
 
-    @ModifyArg(method = "renderButton", index = 1, at = @At(value = "INVOKE", target = "Lcom/mojang/blaze3d/systems/RenderSystem;setShaderTexture(ILnet/minecraft/resources/ResourceLocation;)V"))
+    @ModifyArg(method = "renderWidget", index = 1, at = @At(value = "INVOKE", target = "Lcom/mojang/blaze3d/systems/RenderSystem;setShaderTexture(ILnet/minecraft/resources/ResourceLocation;)V"))
     public ResourceLocation setIcon(ResourceLocation identifier) {
         if (!BetterRecipeBook.config.enablePinning) return identifier;
         return BetterRecipeBook.pinnedRecipeManager.has(this.collection) ? new ResourceLocation("brb:textures/gui/pinned.png") : identifier;
     }
 
-    @ModifyArg(method = "renderButton", index = 3, at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/screens/recipebook/RecipeButton;blit(Lcom/mojang/blaze3d/vertex/PoseStack;IIIIII)V"))
+    @ModifyArg(method = "renderWidget", index = 3, at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/screens/recipebook/RecipeButton;blit(Lcom/mojang/blaze3d/vertex/PoseStack;IIIIII)V"))
     public int fixX(int i) {
         if (!BetterRecipeBook.config.enablePinning) return i;
         return BetterRecipeBook.pinnedRecipeManager.has(this.collection) ? i - 29 : i;
     }
 
-    @ModifyArg(method = "renderButton", index = 4, at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/screens/recipebook/RecipeButton;blit(Lcom/mojang/blaze3d/vertex/PoseStack;IIIIII)V"))
+    @ModifyArg(method = "renderWidget", index = 4, at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/screens/recipebook/RecipeButton;blit(Lcom/mojang/blaze3d/vertex/PoseStack;IIIIII)V"))
     public int fixY(int j) {
         if (!BetterRecipeBook.config.enablePinning) return j;
 

--- a/common/src/main/java/marsh/town/brb/Mixins/Pins/Pins.java
+++ b/common/src/main/java/marsh/town/brb/Mixins/Pins/Pins.java
@@ -44,7 +44,8 @@ public abstract class Pins {
             List<OverlayRecipeComponent.OverlayRecipeButton> alternativeButtons = ((OverlayRecipeComponentAccessor) alternatesWidget).getRecipeButtons();
             for (OverlayRecipeComponent.OverlayRecipeButton alternativeButton : alternativeButtons) {
                 if (alternativeButton.isHoveredOrFocused()) {
-                    RecipeCollection recipeResultCollection = new RecipeCollection(Collections.singletonList(((OverlayRecipeButtonAccessor) alternativeButton).getRecipe()));
+                    assert minecraft.level != null;
+                    RecipeCollection recipeResultCollection = new RecipeCollection(minecraft.level.registryAccess(), Collections.singletonList(((OverlayRecipeButtonAccessor) alternativeButton).getRecipe()));
                     recipeResultCollection.updateKnownRecipes(this.book);
                     BetterRecipeBook.pinnedRecipeManager.addOrRemoveFavourite(recipeResultCollection);
                     this.updateCollections(false);

--- a/common/src/main/java/marsh/town/brb/Mixins/RemoveBookButton.java
+++ b/common/src/main/java/marsh/town/brb/Mixins/RemoveBookButton.java
@@ -23,8 +23,8 @@ public class RemoveBookButton extends Button {
         super(x, y, width, height, message, onPress, DEFAULT_NARRATION);
     }
 
-    @Inject(at = @At("HEAD"), method = "renderButton", cancellable = true)
-    public void renderButton(PoseStack matrices, int mouseX, int mouseY, float delta, CallbackInfo ci) {
+    @Inject(at = @At("HEAD"), method = "renderWidget", cancellable = true)
+    public void renderWidget(PoseStack matrices, int mouseX, int mouseY, float delta, CallbackInfo ci) {
         if (resourceLocation.equals(new ResourceLocation("minecraft:textures/gui/recipe_button.png")) && !BetterRecipeBook.config.enableBook) {
             this.visible = false;
             ci.cancel();

--- a/common/src/main/java/marsh/town/brb/Mixins/SettingsButton.java
+++ b/common/src/main/java/marsh/town/brb/Mixins/SettingsButton.java
@@ -50,14 +50,9 @@ public abstract class SettingsButton {
 
     @Inject(method = "mouseClicked", at = @At("HEAD"), cancellable = true)
     public void mouseClicked(double mouseX, double mouseY, int button, CallbackInfoReturnable<Boolean> cir) {
-        if (this.settingsButton != null) {
-            if (this.settingsButton.mouseClicked(mouseX, mouseY, button) && this.isVisible() && BetterRecipeBook.config.settingsButton) {
-                assert this.minecraft.player != null;
-                if (!this.minecraft.player.isSpectator()) {
-                    if (!this.minecraft.player.isSpectator()) {
-                        cir.setReturnValue(true);
-                    }
-                }
+        if (this.settingsButton != null && BetterRecipeBook.config.settingsButton && this.isVisible()) {
+            if (this.settingsButton.mouseClicked(mouseX, mouseY, button)) {
+                cir.setReturnValue(true);
             }
         }
     }

--- a/common/src/main/java/marsh/town/brb/Mixins/UnGroup/Search.java
+++ b/common/src/main/java/marsh/town/brb/Mixins/UnGroup/Search.java
@@ -30,7 +30,7 @@ public class Search {
         if (BetterRecipeBook.config.alternativeRecipes.noGrouped) {
             list2.removeIf((recipeResultCollection) -> {
                 for (Recipe<?> recipe : recipeResultCollection.getRecipes()) {
-                    return !recipe.getResultItem().getHoverName().getString().toLowerCase(Locale.ROOT).contains(this.lastSearch.toLowerCase(Locale.ROOT));
+                    return !recipe.getResultItem(recipeResultCollection.registryAccess()).getHoverName().getString().toLowerCase(Locale.ROOT).contains(this.lastSearch.toLowerCase(Locale.ROOT));
                 }
                 return false;
             });

--- a/common/src/main/java/marsh/town/brb/Mixins/UnGroup/SplitGrouped.java
+++ b/common/src/main/java/marsh/town/brb/Mixins/UnGroup/SplitGrouped.java
@@ -34,7 +34,7 @@ public class SplitGrouped extends RecipeBook {
                     list2.remove(recipeResultCollection);
 
                     for (Recipe<?> recipe : recipes) {
-                        RecipeCollection recipeResultCollection1 = new RecipeCollection(Collections.singletonList(recipe));
+                        RecipeCollection recipeResultCollection1 = new RecipeCollection(recipeResultCollection.registryAccess(), Collections.singletonList(recipe));
                         recipeResultCollection1.updateKnownRecipes(this);
 
                         list2.add(recipeResultCollection1);

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -33,9 +33,9 @@ dependencies {
 
     modApi "dev.architectury:architectury-fabric:${rootProject.architectury_version}"
 
-    modImplementation "com.terraformersmc:modmenu:5.0.2"
+    modImplementation "com.terraformersmc:modmenu:${rootProject.modmenu_version}"
 
-    modApi("me.shedaniel.cloth:cloth-config-fabric:9.0.94") {
+    modApi("me.shedaniel.cloth:cloth-config-fabric:${rootProject.cloth_config_version}") {
         exclude(group: "net.fabricmc.fabric-api")
     }
 }

--- a/forge/build.gradle
+++ b/forge/build.gradle
@@ -25,7 +25,7 @@ dependencies {
     common(project(path: ":common", configuration: "namedElements")) { transitive false }
     shadowCommon(project(path: ":common", configuration: "transformProductionForge")) { transitive = false }
 
-    modApi "me.shedaniel.cloth:cloth-config-forge:9.0.94"
+    modApi "me.shedaniel.cloth:cloth-config-forge:${rootProject.cloth_config_version}"
 
     modApi "dev.architectury:architectury-forge:${rootProject.architectury_version}"
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,15 +1,18 @@
 org.gradle.jvmargs=-Xmx2048M
 
-minecraft_version=1.19.3
+minecraft_version=1.19.4
 enabled_platforms=fabric,forge
 
 archives_base_name=brb
 mod_version=1.7.0
 maven_group=marsh.town.brb
 
-architectury_version=7.1.70
+architectury_version=8.1.73
 
 fabric_loader_version=0.14.17
-fabric_api_version=0.75.1+1.19.3
+fabric_api_version=0.76.0+1.19.4
 
-forge_version=1.19.3-44.1.0
+forge_version=1.19.4-45.0.9
+
+cloth_config_version=10.0.96
+modmenu_version=6.1.0-rc.4


### PR DESCRIPTION
This seems to be working.

### Changes:
- `renderButton` got renamed to to `renderWidget`.
- `setFocus` got renamed to `setFocused`.
- Some methods now receive a `PoseStack` as first argument.
- Some methods now receive a `RegistryAccess` as first argument. Please double check these changes, I tried my best to pass the correct `RegistryAccess`, but I might have messed up.
- In `RecipeBookWidget`, I could either create an empty `renderWidget` method and continue to override `render` method, or I could override the `renderWidget` method instead. And I did the latter. Please double check this as well.

Also the currently used versions of ModMenu and Forge seem to be in beta phase. Maybe we should wait for them to release the final version.
