### PR TITLE
Feature force place recipe option

### DIFF
--- a/common/src/main/java/marsh/town/brb/config/NewRecipes.java
+++ b/common/src/main/java/marsh/town/brb/config/NewRecipes.java
@@ -5,6 +5,7 @@ import me.shedaniel.autoconfig.annotation.ConfigEntry;
 
 @Config(name = "newRecipes")
 public class NewRecipes {
+    @ConfigEntry.Gui.Tooltip()
     public boolean unlockAll = true;
     @ConfigEntry.Gui.Tooltip()
     public boolean enableBounce = false;

--- a/common/src/main/java/marsh/town/brb/config/NewRecipes.java
+++ b/common/src/main/java/marsh/town/brb/config/NewRecipes.java
@@ -8,6 +8,4 @@ public class NewRecipes {
     public boolean unlockAll = true;
     @ConfigEntry.Gui.Tooltip()
     public boolean enableBounce = false;
-    @ConfigEntry.Gui.Tooltip()
-    public boolean forcePlaceRecipes = false;
 }

--- a/common/src/main/java/marsh/town/brb/config/NewRecipes.java
+++ b/common/src/main/java/marsh/town/brb/config/NewRecipes.java
@@ -8,5 +8,6 @@ public class NewRecipes {
     public boolean unlockAll = true;
     @ConfigEntry.Gui.Tooltip()
     public boolean enableBounce = false;
+    @ConfigEntry.Gui.Tooltip()
     public boolean forcePlaceRecipes = false;
 }

--- a/common/src/main/java/marsh/town/brb/config/NewRecipes.java
+++ b/common/src/main/java/marsh/town/brb/config/NewRecipes.java
@@ -8,4 +8,5 @@ public class NewRecipes {
     public boolean unlockAll = true;
     @ConfigEntry.Gui.Tooltip()
     public boolean enableBounce = false;
+    public boolean forcePlaceRecipes = false;
 }

--- a/common/src/main/java/marsh/town/brb/interfaces/unlockrecipes/IMixinRecipeManager.java
+++ b/common/src/main/java/marsh/town/brb/interfaces/unlockrecipes/IMixinRecipeManager.java
@@ -9,6 +9,6 @@ import java.util.Set;
  */
 public interface IMixinRecipeManager {
 
-    Set<ResourceLocation> _$getServerUnlockedRecipes();
+    Set<ResourceLocation> betterRecipeBook$getServerUnlockedRecipes();
 
 }

--- a/common/src/main/java/marsh/town/brb/interfaces/unlockrecipes/IMixinRecipeManager.java
+++ b/common/src/main/java/marsh/town/brb/interfaces/unlockrecipes/IMixinRecipeManager.java
@@ -1,0 +1,14 @@
+package marsh.town.brb.interfaces.unlockrecipes;
+
+import net.minecraft.resources.ResourceLocation;
+
+import java.util.Set;
+
+/**
+ * Access interface for RecipeManagerMixin
+ */
+public interface IMixinRecipeManager {
+
+    Set<ResourceLocation> _$getServerUnlockedRecipes();
+
+}

--- a/common/src/main/java/marsh/town/brb/mixins/pins/RecipeButtonMixin.java
+++ b/common/src/main/java/marsh/town/brb/mixins/pins/RecipeButtonMixin.java
@@ -1,13 +1,20 @@
 package marsh.town.brb.mixins.pins;
 
 import marsh.town.brb.BetterRecipeBook;
+import marsh.town.brb.interfaces.unlockrecipes.IMixinRecipeManager;
 import marsh.town.brb.util.BRBTextures;
+import net.minecraft.ChatFormatting;
+import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.components.AbstractWidget;
+import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
 import net.minecraft.client.gui.screens.recipebook.RecipeButton;
 import net.minecraft.client.gui.screens.recipebook.RecipeCollection;
 import net.minecraft.network.chat.Component;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.inventory.AbstractFurnaceMenu;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.crafting.RecipeHolder;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
@@ -17,6 +24,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 
 import java.util.List;
+import java.util.Set;
 
 @Mixin(RecipeButton.class)
 public abstract class RecipeButtonMixin extends AbstractWidget {
@@ -25,11 +33,25 @@ public abstract class RecipeButtonMixin extends AbstractWidget {
         super(i, j, k, l, component);
     }
 
-    @Shadow public abstract RecipeCollection getCollection();
+    @Shadow
+    public abstract RecipeCollection getCollection();
+
+    @Shadow
+    public abstract RecipeHolder<?> getRecipe();
 
     @Inject(method = "getTooltipText", locals = LocalCapture.CAPTURE_FAILHARD, at = @At("RETURN"))
     public void getTooltip(CallbackInfoReturnable<List<Component>> cir, ItemStack itemStack, List<Component> list) {
         if (!BetterRecipeBook.config.enablePinning) return;
+
+        Set<ResourceLocation> serverUnlockedRecipes = ((IMixinRecipeManager) Minecraft.getInstance().getConnection().getRecipeManager()).betterRecipeBook$getServerUnlockedRecipes();
+
+        if (!serverUnlockedRecipes.contains(this.getRecipe().id()) && Minecraft.getInstance().screen != null) {
+            if (((AbstractContainerScreen<?>) Minecraft.getInstance().screen).getMenu() instanceof AbstractFurnaceMenu) {
+                list.add(0, Component.translatable("brb.gui.furnace.lockedRecipe").withStyle(ChatFormatting.GRAY).withStyle(ChatFormatting.ITALIC));
+            } else {
+                list.add(0, Component.translatable("brb.gui.crafting.lockedRecipe").withStyle(ChatFormatting.GRAY).withStyle(ChatFormatting.ITALIC));
+            }
+        }
 
         if (BetterRecipeBook.pinnedRecipeManager.has(this.getCollection())) {
             list.add(Component.translatable("brb.gui.pin.remove"));

--- a/common/src/main/java/marsh/town/brb/mixins/unlockrecipes/ClientPacketListenerMixin.java
+++ b/common/src/main/java/marsh/town/brb/mixins/unlockrecipes/ClientPacketListenerMixin.java
@@ -37,7 +37,7 @@ public abstract class ClientPacketListenerMixin {
     @Inject(method = "handleAddOrRemoveRecipes", at = @At(value = "RETURN"))
     public void onAddOrRemoveRecipes(ClientboundRecipePacket packet, CallbackInfo ci) {
         //System.out.println("addOrRemoveRecipes %s: %s".formatted(packet.getState(), Joiner.on(", ").join(packet.getRecipes())));
-        Set<ResourceLocation> serverUnlockedRecipes = ((IMixinRecipeManager) recipeManager)._$getServerUnlockedRecipes();
+        Set<ResourceLocation> serverUnlockedRecipes = ((IMixinRecipeManager) recipeManager).betterRecipeBook$getServerUnlockedRecipes();
         switch (packet.getState()) {
             case INIT:
                 serverUnlockedRecipes.clear();

--- a/common/src/main/java/marsh/town/brb/mixins/unlockrecipes/ClientPacketListenerMixin.java
+++ b/common/src/main/java/marsh/town/brb/mixins/unlockrecipes/ClientPacketListenerMixin.java
@@ -62,7 +62,7 @@ public abstract class ClientPacketListenerMixin {
                 && _$minecraft.player.containerMenu instanceof RecipeBookMenu<?> menu
                 && _$minecraft.player.containerMenu.containerId == packet.getContainerId()
                 && _$minecraft.screen instanceof RecipeUpdateListener rul) {
-            if (!packet.getItem().isEmpty() && RecipeMenuUtil.isCraftingGridSlot(menu, packet.getSlot())) {
+            if (!packet.getItem().isEmpty() && RecipeMenuUtil.isRecipeSlot(menu, packet.getSlot())) {
                 ((RecipeBookComponentAccessor) rul.getRecipeBookComponent()).getGhostRecipe().clear();
             }
         }

--- a/common/src/main/java/marsh/town/brb/mixins/unlockrecipes/ClientPacketListenerMixin.java
+++ b/common/src/main/java/marsh/town/brb/mixins/unlockrecipes/ClientPacketListenerMixin.java
@@ -1,9 +1,10 @@
 package marsh.town.brb.mixins.unlockrecipes;
 
 import marsh.town.brb.BetterRecipeBook;
+import marsh.town.brb.interfaces.unlockrecipes.IMixinRecipeManager;
 import marsh.town.brb.mixins.accessors.RecipeBookComponentAccessor;
 import marsh.town.brb.util.RecipeMenuUtil;
-import marsh.town.brb.util.RecipeUnlocker;
+import marsh.town.brb.util.RecipeUnlockUtil;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.screens.recipebook.RecipeUpdateListener;
 import net.minecraft.client.multiplayer.ClientPacketListener;
@@ -11,12 +12,18 @@ import net.minecraft.network.protocol.game.ClientboundContainerSetSlotPacket;
 import net.minecraft.network.protocol.game.ClientboundPlaceGhostRecipePacket;
 import net.minecraft.network.protocol.game.ClientboundRecipePacket;
 import net.minecraft.network.protocol.game.ClientboundUpdateRecipesPacket;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.inventory.RecipeBookMenu;
+import net.minecraft.world.item.crafting.RecipeManager;
+import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import java.util.Set;
 
 /**
  * Unlocks all recipes that are sent to the client or updated by either the local server or external server
@@ -24,16 +31,28 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 @Mixin(ClientPacketListener.class)
 public abstract class ClientPacketListenerMixin {
 
+    @Shadow @Final private RecipeManager recipeManager;
     @Unique private Minecraft _$minecraft = Minecraft.getInstance();
 
     @Inject(method = "handleAddOrRemoveRecipes", at = @At(value = "RETURN"))
-    public void onAddOrRemoveRecipes(ClientboundRecipePacket clientboundRecipePacket, CallbackInfo ci) {
-        RecipeUnlocker.unlockRecipesIfRequired();
+    public void onAddOrRemoveRecipes(ClientboundRecipePacket packet, CallbackInfo ci) {
+        //System.out.println("addOrRemoveRecipes %s: %s".formatted(packet.getState(), Joiner.on(", ").join(packet.getRecipes())));
+        Set<ResourceLocation> serverUnlockedRecipes = ((IMixinRecipeManager) recipeManager)._$getServerUnlockedRecipes();
+        switch (packet.getState()) {
+            case INIT:
+                serverUnlockedRecipes.clear();
+            case ADD:
+                serverUnlockedRecipes.addAll(packet.getRecipes());
+                break;
+            case REMOVE:
+                packet.getRecipes().forEach(serverUnlockedRecipes::remove);
+        }
+        RecipeUnlockUtil.unlockRecipesIfRequired();
     }
 
     @Inject(method = "handleUpdateRecipes", at = @At(value = "RETURN"))
     public void onUpdateRecipes(ClientboundUpdateRecipesPacket packet, CallbackInfo ci) {
-        RecipeUnlocker.unlockRecipesIfRequired();
+        RecipeUnlockUtil.unlockRecipesIfRequired();
     }
 
     @Inject(method = "handleContainerSetSlot", at = @At(value = "HEAD"))

--- a/common/src/main/java/marsh/town/brb/mixins/unlockrecipes/MultiPlayerGameModeMixin.java
+++ b/common/src/main/java/marsh/town/brb/mixins/unlockrecipes/MultiPlayerGameModeMixin.java
@@ -3,6 +3,8 @@ package marsh.town.brb.mixins.unlockrecipes;
 import marsh.town.brb.BetterRecipeBook;
 import marsh.town.brb.mixins.accessors.RecipeBookComponentAccessor;
 import marsh.town.brb.util.ClientInventoryUtil;
+import marsh.town.brb.util.RecipeMenuUtil;
+import marsh.town.brb.util.RecipePlacement;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.screens.recipebook.RecipeBookComponent;
 import net.minecraft.client.gui.screens.recipebook.RecipeBookPage;
@@ -10,12 +12,14 @@ import net.minecraft.client.gui.screens.recipebook.RecipeCollection;
 import net.minecraft.client.gui.screens.recipebook.RecipeUpdateListener;
 import net.minecraft.client.multiplayer.MultiPlayerGameMode;
 import net.minecraft.world.entity.player.StackedContents;
+import net.minecraft.world.inventory.ClickType;
 import net.minecraft.world.inventory.RecipeBookMenu;
 import net.minecraft.world.inventory.Slot;
 import net.minecraft.world.item.crafting.RecipeHolder;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
@@ -25,13 +29,12 @@ public abstract class MultiPlayerGameModeMixin {
 
     @Shadow @Final private Minecraft minecraft;
 
-    @Inject(method = "handlePlaceRecipe", at = @At(value = "HEAD"))
+    @Inject(method = "handlePlaceRecipe", at = @At(value = "HEAD"), cancellable = true)
     public void onPlaceRecipe(int z, RecipeHolder<?> recipe, boolean bl, CallbackInfo ci) {
         if (BetterRecipeBook.config.newRecipes.unlockAll && minecraft.player != null &&
                 minecraft.screen instanceof RecipeUpdateListener rul && minecraft.player.containerMenu instanceof RecipeBookMenu<?> menu) {
             RecipeBookComponent comp = rul.getRecipeBookComponent();
 
-            // if we don't have all the items place a client side ghost recipe
             RecipeBookPage page = ((RecipeBookComponentAccessor) comp).getRecipeBookPage();
             RecipeCollection lastRecipe = page.getLastClickedRecipeCollection();
             StackedContents contents = new StackedContents();
@@ -40,15 +43,70 @@ public abstract class MultiPlayerGameModeMixin {
             }
             lastRecipe.canCraft(contents, menu.getGridWidth(), menu.getGridHeight(), minecraft.player.getRecipeBook());
 
+            // if we don't have all the items place a client side ghost recipe
             if (!lastRecipe.isCraftable(recipe)) {
                 // remove items from the crafting grid: not all backends do this for us if we haven't unlocked the recipe
-                for (int i = menu.getResultSlotIndex(); i < menu.getSize(); i++) {
-                    ClientInventoryUtil.storeItem(i, idx -> idx < menu.getResultSlotIndex() || idx >= menu.getSize());
-                }
+                _$clearCraftingGrid(menu);
 
                 // place the ghost recipe as we can't craft the recipe yet
                 comp.setupGhostRecipe(recipe, menu.slots);
+            } else if (BetterRecipeBook.config.newRecipes.forcePlaceRecipes) { // otherwise, if we have forcePlaceRecipes enabled, manually place the recipe
+                MultiPlayerGameMode gameMode = Minecraft.getInstance().gameMode;
+
+                // remove items from the crafting grid
+                _$clearCraftingGrid(menu);
+
+                // we are placing the recipe ourselves, don't ask the server to do it.
+                ci.cancel();
+
+                // drop held item if required
+                if (!menu.getCarried().isEmpty()) ClientInventoryUtil.dropItem(-1, true, false);
+
+                // place the recipe in a dummy array to get the correct indexes and ingredients
+                var placement = RecipePlacement.create(recipe, menu.getGridWidth(), menu.getGridHeight());
+                // TODO debug
+                System.out.println(placement);
+
+                for (Slot craftingSlot : menu.slots) {
+                    if (RecipeMenuUtil.isCraftingGridSlot(menu, craftingSlot.index)) {
+                        // TODO debug
+                        System.out.println("run for craftingSlot %d".formatted(craftingSlot.index));
+                        // get the ingredients for this slot in the crafting grid
+                        // we need to adjust out the offset of the result slot when getting the ingredient
+                        var slotIngredients = placement.get(craftingSlot.index - (1 + menu.getResultSlotIndex()));
+
+                        for (Slot inventorySlot : menu.slots) {
+                            // ignore crafting slots to prevent us from taking recipe items already in the crafting grid
+                            if (!RecipeMenuUtil.isCraftingGridSlot(menu, inventorySlot.index)) {
+                                // check if any ingredient is compatible with the item in this inventory slot
+                                if (slotIngredients.stream().anyMatch(i -> i.test(inventorySlot.getItem()))) {
+                                    // TODO debug
+                                    System.out.println("pickup %s at %d, place at %d".formatted(inventorySlot.getItem(), inventorySlot.index, craftingSlot.index));
+                                    // pickup whole stack, deposit one, then return remaining stack
+                                    gameMode.handleInventoryMouseClick(menu.containerId, inventorySlot.index, 0, ClickType.PICKUP, minecraft.player);
+                                    gameMode.handleInventoryMouseClick(menu.containerId, craftingSlot.index, 1, ClickType.PICKUP, minecraft.player);
+                                    if (!menu.getCarried().isEmpty()) {
+                                        gameMode.handleInventoryMouseClick(menu.containerId, inventorySlot.index, 0, ClickType.PICKUP, minecraft.player);
+                                    }
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                }
+
+                // if instant craft is enabled, set last craft
+                if (BetterRecipeBook.instantCraftingManager.on) {
+                    BetterRecipeBook.instantCraftingManager.recipeClicked(recipe.value(), minecraft.level.registryAccess());
+                }
             }
+        }
+    }
+
+    @Unique
+    private static void _$clearCraftingGrid(RecipeBookMenu<?> menu) {
+        for (int i = menu.getResultSlotIndex() + 1; i < menu.getSize(); i++) {
+            ClientInventoryUtil.storeItem(i, idx -> idx < menu.getResultSlotIndex() || idx >= menu.getSize());
         }
     }
 

--- a/common/src/main/java/marsh/town/brb/mixins/unlockrecipes/MultiPlayerGameModeMixin.java
+++ b/common/src/main/java/marsh/town/brb/mixins/unlockrecipes/MultiPlayerGameModeMixin.java
@@ -19,7 +19,6 @@ import net.minecraft.world.item.crafting.RecipeHolder;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
-import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
@@ -30,7 +29,7 @@ public abstract class MultiPlayerGameModeMixin {
     @Shadow @Final private Minecraft minecraft;
 
     @Inject(method = "handlePlaceRecipe", at = @At(value = "HEAD"), cancellable = true)
-    public void onPlaceRecipe(int z, RecipeHolder<?> recipe, boolean bl, CallbackInfo ci) {
+    public void onPlaceRecipe(int z, RecipeHolder<?> recipe, boolean shiftKeyDown, CallbackInfo ci) {
         if (BetterRecipeBook.config.newRecipes.unlockAll && minecraft.player != null &&
                 minecraft.screen instanceof RecipeUpdateListener rul && minecraft.player.containerMenu instanceof RecipeBookMenu<?> menu) {
             RecipeBookComponent comp = rul.getRecipeBookComponent();
@@ -46,42 +45,41 @@ public abstract class MultiPlayerGameModeMixin {
             // if we don't have all the items place a client side ghost recipe
             if (!lastRecipe.isCraftable(recipe)) {
                 // remove items from the crafting grid: not all backends do this for us if we haven't unlocked the recipe
-                _$clearCraftingGrid(menu);
+                for (int i = menu.getResultSlotIndex() + 1; i < menu.getSize(); i++) {
+                    ClientInventoryUtil.storeItem(i, idx -> idx < menu.getResultSlotIndex() || idx >= menu.getSize());
+                }
 
                 // place the ghost recipe as we can't craft the recipe yet
                 comp.setupGhostRecipe(recipe, menu.slots);
-            } else if (BetterRecipeBook.config.newRecipes.forcePlaceRecipes) { // otherwise, if we have forcePlaceRecipes enabled, manually place the recipe
+            } else if (!shiftKeyDown && BetterRecipeBook.config.newRecipes.forcePlaceRecipes) { // otherwise, if we have forcePlaceRecipes enabled, manually place the recipe
                 MultiPlayerGameMode gameMode = Minecraft.getInstance().gameMode;
-
-                // remove items from the crafting grid
-                _$clearCraftingGrid(menu);
 
                 // we are placing the recipe ourselves, don't ask the server to do it.
                 ci.cancel();
 
                 // drop held item if required
-                if (!menu.getCarried().isEmpty()) ClientInventoryUtil.dropItem(-1, true, false);
+                if (!menu.getCarried().isEmpty()) ClientInventoryUtil.storeItem(-1,  idx -> idx < menu.getResultSlotIndex() || idx >= menu.getSize());
 
-                // place the recipe in a dummy array to get the correct indexes and ingredients
+                // get the recipe placement to use to filter items and place them in the crafting grid
                 var placement = RecipePlacement.create(recipe, menu.getGridWidth(), menu.getGridHeight());
-                // TODO debug
-                System.out.println(placement);
 
                 for (Slot craftingSlot : menu.slots) {
                     if (RecipeMenuUtil.isCraftingGridSlot(menu, craftingSlot.index)) {
-                        // TODO debug
-                        System.out.println("run for craftingSlot %d".formatted(craftingSlot.index));
                         // get the ingredients for this slot in the crafting grid
                         // we need to adjust out the offset of the result slot when getting the ingredient
                         var slotIngredients = placement.get(craftingSlot.index - (1 + menu.getResultSlotIndex()));
 
+                        // if the item in the crafting grid doesn't match the recipe, remove it.
+                        if (!craftingSlot.getItem().isEmpty() && (slotIngredients.isEmpty() || slotIngredients.stream().anyMatch(i -> !i.test(craftingSlot.getItem())))) {
+                            ClientInventoryUtil.storeItem(craftingSlot.index, idx -> idx < menu.getResultSlotIndex() || idx >= menu.getSize());
+                        }
+
+                        // find items to put in the crafting grid
                         for (Slot inventorySlot : menu.slots) {
                             // ignore crafting slots to prevent us from taking recipe items already in the crafting grid
                             if (!RecipeMenuUtil.isCraftingGridSlot(menu, inventorySlot.index)) {
                                 // check if any ingredient is compatible with the item in this inventory slot
                                 if (slotIngredients.stream().anyMatch(i -> i.test(inventorySlot.getItem()))) {
-                                    // TODO debug
-                                    System.out.println("pickup %s at %d, place at %d".formatted(inventorySlot.getItem(), inventorySlot.index, craftingSlot.index));
                                     // pickup whole stack, deposit one, then return remaining stack
                                     gameMode.handleInventoryMouseClick(menu.containerId, inventorySlot.index, 0, ClickType.PICKUP, minecraft.player);
                                     gameMode.handleInventoryMouseClick(menu.containerId, craftingSlot.index, 1, ClickType.PICKUP, minecraft.player);
@@ -96,17 +94,10 @@ public abstract class MultiPlayerGameModeMixin {
                 }
 
                 // if instant craft is enabled, set last craft
-                if (BetterRecipeBook.instantCraftingManager.on) {
+                if (BetterRecipeBook.instantCraftingManager.on && !menu.getSlot(menu.getResultSlotIndex()).getItem().isEmpty()) {
                     BetterRecipeBook.instantCraftingManager.recipeClicked(recipe.value(), minecraft.level.registryAccess());
                 }
             }
-        }
-    }
-
-    @Unique
-    private static void _$clearCraftingGrid(RecipeBookMenu<?> menu) {
-        for (int i = menu.getResultSlotIndex() + 1; i < menu.getSize(); i++) {
-            ClientInventoryUtil.storeItem(i, idx -> idx < menu.getResultSlotIndex() || idx >= menu.getSize());
         }
     }
 

--- a/common/src/main/java/marsh/town/brb/mixins/unlockrecipes/MultiPlayerGameModeMixin.java
+++ b/common/src/main/java/marsh/town/brb/mixins/unlockrecipes/MultiPlayerGameModeMixin.java
@@ -111,13 +111,13 @@ public abstract class MultiPlayerGameModeMixin {
 
             Set<ResourceLocation> serverUnlockedRecipes = ((IMixinRecipeManager) minecraft.getConnection().getRecipeManager())._$getServerUnlockedRecipes();
 
+            // remove items from the crafting grid
+            for (int i = 0; i < menu.getSize() && i != menu.getResultSlotIndex(); i++) {
+                ClientInventoryUtil.storeItem(i, idx -> idx < menu.getResultSlotIndex() || idx >= menu.getSize());
+            }
+
             // if we don't have all the items place a client side ghost recipe
             if (!lastRecipe.isCraftable(recipe)) {
-                // remove items from the crafting grid: not all backends do this for us if we haven't unlocked the recipe
-                for (int i = 0; i < menu.getSize() && i != menu.getResultSlotIndex(); i++) {
-                    ClientInventoryUtil.storeItem(i, idx -> idx < menu.getResultSlotIndex() || idx >= menu.getSize());
-                }
-
                 // place the ghost recipe as we can't craft the recipe yet
                 comp.setupGhostRecipe(recipe, menu.slots);
 

--- a/common/src/main/java/marsh/town/brb/mixins/unlockrecipes/MultiPlayerGameModeMixin.java
+++ b/common/src/main/java/marsh/town/brb/mixins/unlockrecipes/MultiPlayerGameModeMixin.java
@@ -57,7 +57,7 @@ public abstract class MultiPlayerGameModeMixin {
             }
             lastRecipe.canCraft(contents, menu.getGridWidth(), menu.getGridHeight(), minecraft.player.getRecipeBook());
 
-            Set<ResourceLocation> serverUnlockedRecipes = ((IMixinRecipeManager) minecraft.getConnection().getRecipeManager())._$getServerUnlockedRecipes();
+            Set<ResourceLocation> serverUnlockedRecipes = ((IMixinRecipeManager) minecraft.getConnection().getRecipeManager()).betterRecipeBook$getServerUnlockedRecipes();
 
             // if we don't have all the items place a client side ghost recipe
             if (!lastRecipe.isCraftable(recipe)) {
@@ -69,7 +69,7 @@ public abstract class MultiPlayerGameModeMixin {
                 // place the ghost recipe as we can't craft the recipe yet
                 comp.setupGhostRecipe(recipe, menu.slots);
 
-                // don't send requests to the server that we shouldn't
+                // don't send recipe requests to the server that we don't have
                 if (!serverUnlockedRecipes.contains(recipe.id())) ci.cancel();
             } else if (!serverUnlockedRecipes.contains(recipe.id())) { // if the server didn't unlock this recipe for us, manually place the recipe
                 MultiPlayerGameMode gameMode = minecraft.gameMode;
@@ -115,13 +115,16 @@ public abstract class MultiPlayerGameModeMixin {
                     }
                 }
 
-                if (menu instanceof AbstractFurnaceMenu && menu.getSlot(menu.getResultSlotIndex()).hasItem()) {
-                    ClientInventoryUtil.storeItem(menu.getResultSlotIndex(), idx -> idx != menu.getResultSlotIndex() || idx >= menu.getSize());
-                }
-
-                // if instant craft is enabled, set last craft
-                if (BetterRecipeBook.instantCraftingManager.on && !menu.getSlot(menu.getResultSlotIndex()).getItem().isEmpty()) {
-                    BetterRecipeBook.instantCraftingManager.recipeClicked(recipe.value(), minecraft.level.registryAccess());
+                if (menu instanceof AbstractFurnaceMenu) {
+                    // furnace menus are supposed to take out the result item when a recipe is placed
+                    if (menu.getSlot(menu.getResultSlotIndex()).hasItem()) {
+                        ClientInventoryUtil.storeItem(menu.getResultSlotIndex(), idx -> idx != menu.getResultSlotIndex() || idx >= menu.getSize());
+                    }
+                } else {
+                    // if instant craft is enabled, set last craft
+                    if (BetterRecipeBook.instantCraftingManager.on && !menu.getSlot(menu.getResultSlotIndex()).getItem().isEmpty()) {
+                        BetterRecipeBook.instantCraftingManager.recipeClicked(recipe.value(), minecraft.level.registryAccess());
+                    }
                 }
             }
         }

--- a/common/src/main/java/marsh/town/brb/mixins/unlockrecipes/MultiPlayerGameModeMixin.java
+++ b/common/src/main/java/marsh/town/brb/mixins/unlockrecipes/MultiPlayerGameModeMixin.java
@@ -11,32 +11,84 @@ import net.minecraft.client.gui.screens.recipebook.RecipeBookComponent;
 import net.minecraft.client.gui.screens.recipebook.RecipeBookPage;
 import net.minecraft.client.gui.screens.recipebook.RecipeCollection;
 import net.minecraft.client.gui.screens.recipebook.RecipeUpdateListener;
-import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraft.client.multiplayer.MultiPlayerGameMode;
-import net.minecraft.client.multiplayer.prediction.PredictiveAction;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.player.StackedContents;
 import net.minecraft.world.inventory.ClickType;
 import net.minecraft.world.inventory.RecipeBookMenu;
 import net.minecraft.world.inventory.Slot;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.crafting.Ingredient;
 import net.minecraft.world.item.crafting.RecipeHolder;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 @Mixin(MultiPlayerGameMode.class)
 public abstract class MultiPlayerGameModeMixin {
 
-    @Shadow @Final private Minecraft minecraft;
+    @Shadow
+    @Final
+    private Minecraft minecraft;
 
-    @Shadow protected abstract void startPrediction(ClientLevel arg, PredictiveAction arg2);
+    @Unique
+    private void betterRecipeBook$placeSlots(Map<Slot, ItemStack> itemStackMap, RecipeBookMenu<?> menu, List<List<Ingredient>> placement, MultiPlayerGameMode gameMode) {
+        for (Slot craftingSlot : itemStackMap.keySet()) {
+            if (RecipeMenuUtil.isRecipeSlot(menu, craftingSlot.index)) {
+                // get the ingredients for this slot in the crafting grid
+                // we need to adjust out the offset of the result slot when getting the ingredient for crafting tables
+                var slotIngredients = placement.get(craftingSlot.index - (menu.getResultSlotIndex() > 0 ? 0 : 1));
 
-    @Shadow private int carriedIndex;
+                // if the item in the crafting grid doesn't match the recipe, remove it.
+                if (!craftingSlot.getItem().isEmpty() && (slotIngredients.isEmpty() || slotIngredients.stream().anyMatch(i -> !i.test(craftingSlot.getItem())))) {
+                    ClientInventoryUtil.storeItem(craftingSlot.index, idx -> idx < menu.getResultSlotIndex() || idx >= menu.getSize());
+                }
+
+                // find items to put in the crafting grid
+                for (Map.Entry<Slot, ItemStack> inventorySlot : itemStackMap.entrySet()) {
+                    // ignore crafting slots to prevent us from taking recipe items already in the crafting grid
+                    if (!RecipeMenuUtil.isRecipeSlot(menu, inventorySlot.getKey().index)) {
+                        // check if any ingredient is compatible with the item in this inventory slot
+                        if (slotIngredients.stream().anyMatch(i -> i.test(inventorySlot.getKey().getItem()))) {
+                            // pickup whole stack, deposit one, then return remaining stack
+                            gameMode.handleInventoryMouseClick(menu.containerId, inventorySlot.getKey().index, 0, ClickType.PICKUP, minecraft.player);
+                            gameMode.handleInventoryMouseClick(menu.containerId, craftingSlot.index, 1, ClickType.PICKUP, minecraft.player);
+                            if (!menu.getCarried().isEmpty()) {
+                                gameMode.handleInventoryMouseClick(menu.containerId, inventorySlot.getKey().index, 0, ClickType.PICKUP, minecraft.player);
+                            }
+
+                            inventorySlot.getValue().setCount(inventorySlot.getValue().getCount() - 1);
+
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @Unique
+    private StackedContents betterRecipeBook$createContents(Map<Slot, ItemStack> slots, RecipeBookMenu<?> menu, boolean ignoreCraftingSlots) {
+        StackedContents contents = new StackedContents();
+        for (Map.Entry<Slot, ItemStack> slot : slots.entrySet()) {
+            if (ignoreCraftingSlots && RecipeMenuUtil.isRecipeSlot(menu, slot.getKey().index)) {
+                continue;
+            }
+
+            if (slot.getKey().index != menu.getResultSlotIndex()) contents.accountStack(slot.getValue());
+        }
+
+        return contents;
+    }
 
     @Inject(method = "handlePlaceRecipe", at = @At(value = "HEAD"), cancellable = true)
     public void onPlaceRecipe(int z, RecipeHolder<?> recipe, boolean shiftKeyDown, CallbackInfo ci) {
@@ -44,12 +96,17 @@ public abstract class MultiPlayerGameModeMixin {
                 minecraft.screen instanceof RecipeUpdateListener rul && minecraft.player.containerMenu instanceof RecipeBookMenu<?> menu) {
             RecipeBookComponent comp = rul.getRecipeBookComponent();
 
+            // Slots are accessed and used normally, but we keep track of virtual itemStacks and decrement their count
+            // every time we place an item, allowing us to calculate if a recipe is still craft-able
+            Map<Slot, ItemStack> slotItemStackMap = new HashMap<>();
+
+            for (Slot slot : menu.slots) {
+                slotItemStackMap.put(slot, slot.getItem().copy());
+            }
+
             RecipeBookPage page = ((RecipeBookComponentAccessor) comp).getRecipeBookPage();
             RecipeCollection lastRecipe = page.getLastClickedRecipeCollection();
-            StackedContents contents = new StackedContents();
-            for (Slot slot : menu.slots) {
-                if (slot.index != menu.getResultSlotIndex()) contents.accountStack(slot.getItem());
-            }
+            StackedContents contents = betterRecipeBook$createContents(slotItemStackMap, menu, false);
             lastRecipe.canCraft(contents, menu.getGridWidth(), menu.getGridHeight(), minecraft.player.getRecipeBook());
 
             Set<ResourceLocation> serverUnlockedRecipes = ((IMixinRecipeManager) minecraft.getConnection().getRecipeManager())._$getServerUnlockedRecipes();
@@ -73,41 +130,24 @@ public abstract class MultiPlayerGameModeMixin {
                 ci.cancel();
 
                 // store/drop held item if required
-                if (!menu.getCarried().isEmpty()) ClientInventoryUtil.storeItem(-1, idx -> idx < menu.getResultSlotIndex() || idx >= menu.getSize());
+                if (!menu.getCarried().isEmpty())
+                    ClientInventoryUtil.storeItem(-1, idx -> idx < menu.getResultSlotIndex() || idx >= menu.getSize());
 
                 // get the recipe placement to use to filter items and place them in the crafting grid
                 var placement = RecipePlacement.create(recipe, menu.getGridWidth(), menu.getGridHeight());
                 //System.out.println("placement: " + Joiner.on(", ").join(placement.stream().map(s -> s.stream().map(i -> i.toJson(true)).toList()).toList()));
 
-                for (Slot craftingSlot : menu.slots) {
-                    if (RecipeMenuUtil.isRecipeSlot(menu, craftingSlot.index)) {
-                        // get the ingredients for this slot in the crafting grid
-                        // we need to adjust out the offset of the result slot when getting the ingredient for crafting tables
-                        var slotIngredients = placement.get(craftingSlot.index - (menu.getResultSlotIndex() > 0 ? 0 : 1));
+                if (shiftKeyDown) {
+                    // Repeat until uncraftable when holding shift
+                    while (contents.canCraft(recipe.value(), null)) {
+                        this.betterRecipeBook$placeSlots(slotItemStackMap, menu, placement, gameMode);
 
-                        // if the item in the crafting grid doesn't match the recipe, remove it.
-                        if (!craftingSlot.getItem().isEmpty() && (slotIngredients.isEmpty() || slotIngredients.stream().anyMatch(i -> !i.test(craftingSlot.getItem())))) {
-                            ClientInventoryUtil.storeItem(craftingSlot.index, idx -> idx < menu.getResultSlotIndex() || idx >= menu.getSize());
-                        }
-
-                        // find items to put in the crafting grid
-                        for (Slot inventorySlot : menu.slots) {
-                            // ignore crafting slots to prevent us from taking recipe items already in the crafting grid
-                            if (!RecipeMenuUtil.isRecipeSlot(menu, inventorySlot.index)) {
-                                // check if any ingredient is compatible with the item in this inventory slot
-                                if (slotIngredients.stream().anyMatch(i -> i.test(inventorySlot.getItem()))) {
-                                    // pickup whole stack, deposit one, then return remaining stack
-                                    gameMode.handleInventoryMouseClick(menu.containerId, inventorySlot.index, 0, ClickType.PICKUP, minecraft.player);
-                                    gameMode.handleInventoryMouseClick(menu.containerId, craftingSlot.index, 1, ClickType.PICKUP, minecraft.player);
-                                    if (!menu.getCarried().isEmpty()) {
-                                        gameMode.handleInventoryMouseClick(menu.containerId, inventorySlot.index, 0, ClickType.PICKUP, minecraft.player);
-                                    }
-                                    break;
-                                }
-                            }
-                        }
+                        contents = betterRecipeBook$createContents(slotItemStackMap, menu, true);
                     }
+                } else {
+                    this.betterRecipeBook$placeSlots(slotItemStackMap, menu, placement, gameMode);
                 }
+
 
                 // if instant craft is enabled, set last craft
                 if (BetterRecipeBook.instantCraftingManager.on && !menu.getSlot(menu.getResultSlotIndex()).getItem().isEmpty()) {

--- a/common/src/main/java/marsh/town/brb/mixins/unlockrecipes/MultiPlayerGameModeMixin.java
+++ b/common/src/main/java/marsh/town/brb/mixins/unlockrecipes/MultiPlayerGameModeMixin.java
@@ -14,6 +14,7 @@ import net.minecraft.client.gui.screens.recipebook.RecipeUpdateListener;
 import net.minecraft.client.multiplayer.MultiPlayerGameMode;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.player.StackedContents;
+import net.minecraft.world.inventory.AbstractFurnaceMenu;
 import net.minecraft.world.inventory.ClickType;
 import net.minecraft.world.inventory.RecipeBookMenu;
 import net.minecraft.world.inventory.Slot;
@@ -50,7 +51,7 @@ public abstract class MultiPlayerGameModeMixin {
 
                 // if the item in the crafting grid doesn't match the recipe, remove it.
                 if (!craftingSlot.getItem().isEmpty() && (slotIngredients.isEmpty() || slotIngredients.stream().anyMatch(i -> !i.test(craftingSlot.getItem())))) {
-                    ClientInventoryUtil.storeItem(craftingSlot.index, idx -> idx < menu.getResultSlotIndex() || idx >= menu.getSize());
+                    ClientInventoryUtil.storeItem(craftingSlot.index, idx -> idx != menu.getResultSlotIndex() || idx >= menu.getSize());
                 }
 
                 // find items to put in the crafting grid
@@ -113,7 +114,7 @@ public abstract class MultiPlayerGameModeMixin {
 
             // remove items from the crafting grid
             for (int i = 0; i < menu.getSize() && i != menu.getResultSlotIndex(); i++) {
-                ClientInventoryUtil.storeItem(i, idx -> idx < menu.getResultSlotIndex() || idx >= menu.getSize());
+                ClientInventoryUtil.storeItem(i, idx -> idx != menu.getResultSlotIndex() || idx >= menu.getSize());
             }
 
             // if we don't have all the items place a client side ghost recipe
@@ -131,7 +132,7 @@ public abstract class MultiPlayerGameModeMixin {
 
                 // store/drop held item if required
                 if (!menu.getCarried().isEmpty())
-                    ClientInventoryUtil.storeItem(-1, idx -> idx < menu.getResultSlotIndex() || idx >= menu.getSize());
+                    ClientInventoryUtil.storeItem(-1, idx -> idx != menu.getResultSlotIndex() || idx >= menu.getSize());
 
                 // get the recipe placement to use to filter items and place them in the crafting grid
                 var placement = RecipePlacement.create(recipe, menu.getGridWidth(), menu.getGridHeight());
@@ -148,6 +149,9 @@ public abstract class MultiPlayerGameModeMixin {
                     this.betterRecipeBook$placeSlots(slotItemStackMap, menu, placement, gameMode);
                 }
 
+                if (menu instanceof AbstractFurnaceMenu && menu.getSlot(menu.getResultSlotIndex()).hasItem()) {
+                    ClientInventoryUtil.storeItem(menu.getResultSlotIndex(), idx -> idx != menu.getResultSlotIndex() || idx >= menu.getSize());
+                }
 
                 // if instant craft is enabled, set last craft
                 if (BetterRecipeBook.instantCraftingManager.on && !menu.getSlot(menu.getResultSlotIndex()).getItem().isEmpty()) {

--- a/common/src/main/java/marsh/town/brb/mixins/unlockrecipes/MultiPlayerGameModeMixin.java
+++ b/common/src/main/java/marsh/town/brb/mixins/unlockrecipes/MultiPlayerGameModeMixin.java
@@ -11,27 +11,23 @@ import net.minecraft.client.gui.screens.recipebook.RecipeBookComponent;
 import net.minecraft.client.gui.screens.recipebook.RecipeBookPage;
 import net.minecraft.client.gui.screens.recipebook.RecipeCollection;
 import net.minecraft.client.gui.screens.recipebook.RecipeUpdateListener;
+import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraft.client.multiplayer.MultiPlayerGameMode;
+import net.minecraft.client.multiplayer.prediction.PredictiveAction;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.player.StackedContents;
 import net.minecraft.world.inventory.AbstractFurnaceMenu;
 import net.minecraft.world.inventory.ClickType;
 import net.minecraft.world.inventory.RecipeBookMenu;
 import net.minecraft.world.inventory.Slot;
-import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.item.crafting.Ingredient;
 import net.minecraft.world.item.crafting.RecipeHolder;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
-import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 @Mixin(MultiPlayerGameMode.class)
@@ -41,55 +37,11 @@ public abstract class MultiPlayerGameModeMixin {
     @Final
     private Minecraft minecraft;
 
-    @Unique
-    private void betterRecipeBook$placeSlots(Map<Slot, ItemStack> itemStackMap, RecipeBookMenu<?> menu, List<List<Ingredient>> placement, MultiPlayerGameMode gameMode) {
-        for (Slot craftingSlot : itemStackMap.keySet()) {
-            if (RecipeMenuUtil.isRecipeSlot(menu, craftingSlot.index)) {
-                // get the ingredients for this slot in the crafting grid
-                // we need to adjust out the offset of the result slot when getting the ingredient for crafting tables
-                var slotIngredients = placement.get(craftingSlot.index - (menu.getResultSlotIndex() > 0 ? 0 : 1));
+    @Shadow
+    protected abstract void startPrediction(ClientLevel arg, PredictiveAction arg2);
 
-                // if the item in the crafting grid doesn't match the recipe, remove it.
-                if (!craftingSlot.getItem().isEmpty() && (slotIngredients.isEmpty() || slotIngredients.stream().anyMatch(i -> !i.test(craftingSlot.getItem())))) {
-                    ClientInventoryUtil.storeItem(craftingSlot.index, idx -> idx != menu.getResultSlotIndex() || idx >= menu.getSize());
-                }
-
-                // find items to put in the crafting grid
-                for (Map.Entry<Slot, ItemStack> inventorySlot : itemStackMap.entrySet()) {
-                    // ignore crafting slots to prevent us from taking recipe items already in the crafting grid
-                    if (!RecipeMenuUtil.isRecipeSlot(menu, inventorySlot.getKey().index)) {
-                        // check if any ingredient is compatible with the item in this inventory slot
-                        if (slotIngredients.stream().anyMatch(i -> i.test(inventorySlot.getKey().getItem()))) {
-                            // pickup whole stack, deposit one, then return remaining stack
-                            gameMode.handleInventoryMouseClick(menu.containerId, inventorySlot.getKey().index, 0, ClickType.PICKUP, minecraft.player);
-                            gameMode.handleInventoryMouseClick(menu.containerId, craftingSlot.index, 1, ClickType.PICKUP, minecraft.player);
-                            if (!menu.getCarried().isEmpty()) {
-                                gameMode.handleInventoryMouseClick(menu.containerId, inventorySlot.getKey().index, 0, ClickType.PICKUP, minecraft.player);
-                            }
-
-                            inventorySlot.getValue().setCount(inventorySlot.getValue().getCount() - 1);
-
-                            break;
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    @Unique
-    private StackedContents betterRecipeBook$createContents(Map<Slot, ItemStack> slots, RecipeBookMenu<?> menu, boolean ignoreCraftingSlots) {
-        StackedContents contents = new StackedContents();
-        for (Map.Entry<Slot, ItemStack> slot : slots.entrySet()) {
-            if (ignoreCraftingSlots && RecipeMenuUtil.isRecipeSlot(menu, slot.getKey().index)) {
-                continue;
-            }
-
-            if (slot.getKey().index != menu.getResultSlotIndex()) contents.accountStack(slot.getValue());
-        }
-
-        return contents;
-    }
+    @Shadow
+    private int carriedIndex;
 
     @Inject(method = "handlePlaceRecipe", at = @At(value = "HEAD"), cancellable = true)
     public void onPlaceRecipe(int z, RecipeHolder<?> recipe, boolean shiftKeyDown, CallbackInfo ci) {
@@ -97,28 +49,23 @@ public abstract class MultiPlayerGameModeMixin {
                 minecraft.screen instanceof RecipeUpdateListener rul && minecraft.player.containerMenu instanceof RecipeBookMenu<?> menu) {
             RecipeBookComponent comp = rul.getRecipeBookComponent();
 
-            // Slots are accessed and used normally, but we keep track of virtual itemStacks and decrement their count
-            // every time we place an item, allowing us to calculate if a recipe is still craft-able
-            Map<Slot, ItemStack> slotItemStackMap = new HashMap<>();
-
-            for (Slot slot : menu.slots) {
-                slotItemStackMap.put(slot, slot.getItem().copy());
-            }
-
             RecipeBookPage page = ((RecipeBookComponentAccessor) comp).getRecipeBookPage();
             RecipeCollection lastRecipe = page.getLastClickedRecipeCollection();
-            StackedContents contents = betterRecipeBook$createContents(slotItemStackMap, menu, false);
+            StackedContents contents = new StackedContents();
+            for (Slot slot : menu.slots) {
+                if (slot.index != menu.getResultSlotIndex()) contents.accountStack(slot.getItem());
+            }
             lastRecipe.canCraft(contents, menu.getGridWidth(), menu.getGridHeight(), minecraft.player.getRecipeBook());
 
             Set<ResourceLocation> serverUnlockedRecipes = ((IMixinRecipeManager) minecraft.getConnection().getRecipeManager())._$getServerUnlockedRecipes();
 
-            // remove items from the crafting grid
-            for (int i = 0; i < menu.getSize() && i != menu.getResultSlotIndex(); i++) {
-                ClientInventoryUtil.storeItem(i, idx -> idx != menu.getResultSlotIndex() || idx >= menu.getSize());
-            }
-
             // if we don't have all the items place a client side ghost recipe
             if (!lastRecipe.isCraftable(recipe)) {
+                // remove items from the crafting grid: not all backends do this for us if we haven't unlocked the recipe
+                for (int i = 0; i < menu.getSize() && i != menu.getResultSlotIndex(); i++) {
+                    ClientInventoryUtil.storeItem(i, idx -> idx != menu.getResultSlotIndex() || idx >= menu.getSize());
+                }
+
                 // place the ghost recipe as we can't craft the recipe yet
                 comp.setupGhostRecipe(recipe, menu.slots);
 
@@ -138,15 +85,34 @@ public abstract class MultiPlayerGameModeMixin {
                 var placement = RecipePlacement.create(recipe, menu.getGridWidth(), menu.getGridHeight());
                 //System.out.println("placement: " + Joiner.on(", ").join(placement.stream().map(s -> s.stream().map(i -> i.toJson(true)).toList()).toList()));
 
-                if (shiftKeyDown) {
-                    // Repeat until uncraftable when holding shift
-                    while (contents.canCraft(recipe.value(), null)) {
-                        this.betterRecipeBook$placeSlots(slotItemStackMap, menu, placement, gameMode);
+                for (Slot craftingSlot : menu.slots) {
+                    if (RecipeMenuUtil.isRecipeSlot(menu, craftingSlot.index)) {
+                        // get the ingredients for this slot in the crafting grid
+                        // we need to adjust out the offset of the result slot when getting the ingredient for crafting tables
+                        var slotIngredients = placement.get(craftingSlot.index - (menu.getResultSlotIndex() > 0 ? 0 : 1));
 
-                        contents = betterRecipeBook$createContents(slotItemStackMap, menu, true);
+                        // if the item in the crafting grid doesn't match the recipe, remove it.
+                        if (!craftingSlot.getItem().isEmpty() && (slotIngredients.isEmpty() || slotIngredients.stream().anyMatch(i -> !i.test(craftingSlot.getItem())))) {
+                            ClientInventoryUtil.storeItem(craftingSlot.index, idx -> idx != menu.getResultSlotIndex() || idx >= menu.getSize());
+                        }
+
+                        // find items to put in the crafting grid
+                        for (Slot inventorySlot : menu.slots) {
+                            // ignore crafting slots to prevent us from taking recipe items already in the crafting grid
+                            if (!RecipeMenuUtil.isRecipeSlot(menu, inventorySlot.index)) {
+                                // check if any ingredient is compatible with the item in this inventory slot
+                                if (slotIngredients.stream().anyMatch(i -> i.test(inventorySlot.getItem()))) {
+                                    // pickup whole stack, deposit one, then return remaining stack
+                                    gameMode.handleInventoryMouseClick(menu.containerId, inventorySlot.index, 0, ClickType.PICKUP, minecraft.player);
+                                    gameMode.handleInventoryMouseClick(menu.containerId, craftingSlot.index, 1, ClickType.PICKUP, minecraft.player);
+                                    if (!menu.getCarried().isEmpty()) {
+                                        gameMode.handleInventoryMouseClick(menu.containerId, inventorySlot.index, 0, ClickType.PICKUP, minecraft.player);
+                                    }
+                                    break;
+                                }
+                            }
+                        }
                     }
-                } else {
-                    this.betterRecipeBook$placeSlots(slotItemStackMap, menu, placement, gameMode);
                 }
 
                 if (menu instanceof AbstractFurnaceMenu && menu.getSlot(menu.getResultSlotIndex()).hasItem()) {

--- a/common/src/main/java/marsh/town/brb/mixins/unlockrecipes/RecipeManagerMixin.java
+++ b/common/src/main/java/marsh/town/brb/mixins/unlockrecipes/RecipeManagerMixin.java
@@ -15,11 +15,11 @@ public class RecipeManagerMixin implements IMixinRecipeManager {
     // map for keeping track of unlocked recipes
     // we want this to be an instance variable to avoid any funny business
     @Unique
-    private final Set<ResourceLocation> serverUnlockedRecipes = new HashSet<>();
+    private final Set<ResourceLocation> betterRecipeBook$serverUnlockedRecipes = new HashSet<>();
 
     @Override
-    public Set<ResourceLocation> _$getServerUnlockedRecipes() {
-        return serverUnlockedRecipes;
+    public Set<ResourceLocation> betterRecipeBook$getServerUnlockedRecipes() {
+        return betterRecipeBook$serverUnlockedRecipes;
     }
 
 }

--- a/common/src/main/java/marsh/town/brb/mixins/unlockrecipes/RecipeManagerMixin.java
+++ b/common/src/main/java/marsh/town/brb/mixins/unlockrecipes/RecipeManagerMixin.java
@@ -1,0 +1,25 @@
+package marsh.town.brb.mixins.unlockrecipes;
+
+import marsh.town.brb.interfaces.unlockrecipes.IMixinRecipeManager;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.crafting.RecipeManager;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+
+import java.util.HashSet;
+import java.util.Set;
+
+@Mixin(RecipeManager.class)
+public class RecipeManagerMixin implements IMixinRecipeManager {
+
+    // map for keeping track of unlocked recipes
+    // we want this to be an instance variable to avoid any funny business
+    @Unique
+    private final Set<ResourceLocation> serverUnlockedRecipes = new HashSet<>();
+
+    @Override
+    public Set<ResourceLocation> _$getServerUnlockedRecipes() {
+        return serverUnlockedRecipes;
+    }
+
+}

--- a/common/src/main/java/marsh/town/brb/util/RecipeMenuUtil.java
+++ b/common/src/main/java/marsh/town/brb/util/RecipeMenuUtil.java
@@ -1,19 +1,28 @@
 package marsh.town.brb.util;
 
+import net.minecraft.world.inventory.AbstractFurnaceMenu;
 import net.minecraft.world.inventory.RecipeBookMenu;
 
 public class RecipeMenuUtil {
+
+    public static boolean isRecipeSlot(RecipeBookMenu<?> menu, int slot) {
+        if (menu instanceof AbstractFurnaceMenu) {
+            return AbstractFurnaceMenu.INGREDIENT_SLOT == slot;
+        } else {
+            return isCraftingGridSlot(menu, slot);
+        }
+    }
 
     public static boolean isCraftingGridSlot(RecipeBookMenu<?> menu, int slot) {
         return slot > menu.getResultSlotIndex() && slot < menu.getSize();
     }
 
-    public static boolean isCraftingResultSlot(RecipeBookMenu<?> menu, int slot) {
+    public static boolean isResultSlot(RecipeBookMenu<?> menu, int slot) {
         return menu.getResultSlotIndex() == slot;
     }
 
     public static boolean isCraftingMenuSlot(RecipeBookMenu<?> menu, int slot) {
-        return isCraftingGridSlot(menu, slot) || isCraftingResultSlot(menu, slot);
+        return isCraftingGridSlot(menu, slot) || isResultSlot(menu, slot);
     }
 
 }

--- a/common/src/main/java/marsh/town/brb/util/RecipePlacement.java
+++ b/common/src/main/java/marsh/town/brb/util/RecipePlacement.java
@@ -1,0 +1,37 @@
+package marsh.town.brb.util;
+
+import net.minecraft.recipebook.PlaceRecipe;
+import net.minecraft.world.item.crafting.Ingredient;
+import net.minecraft.world.item.crafting.RecipeHolder;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+public class RecipePlacement implements PlaceRecipe<Ingredient> {
+
+    protected List<List<Ingredient>> placement = new ArrayList<>();
+
+    public RecipePlacement(int size) {
+        for (int i = 0; i < size; i++) placement.add(new ArrayList<>());
+    }
+
+    @Override
+    public void addItemToSlot(Iterator<Ingredient> iterator, int menuSlot, int j, int k, int l) {
+        Ingredient ingredient = iterator.next();
+        if (!ingredient.isEmpty() && menuSlot < placement.size()) {
+            placement.get(menuSlot).add(ingredient);
+        }
+    }
+
+    public List<List<Ingredient>> getPlacement() {
+        return placement;
+    }
+
+    public static List<List<Ingredient>> create(RecipeHolder<?> recipe, int gridWidth, int gridHeight) {
+        RecipePlacement placer = new RecipePlacement(gridWidth * gridHeight);
+        placer.placeRecipe(gridWidth, gridHeight, -1, recipe, recipe.value().getIngredients().iterator(), 0);
+        return placer.getPlacement();
+    }
+
+}

--- a/common/src/main/java/marsh/town/brb/util/RecipeUnlockUtil.java
+++ b/common/src/main/java/marsh/town/brb/util/RecipeUnlockUtil.java
@@ -7,7 +7,7 @@ import net.minecraft.client.gui.screens.recipebook.RecipeUpdateListener;
 import net.minecraft.client.player.LocalPlayer;
 import net.minecraft.world.item.crafting.RecipeManager;
 
-public class RecipeUnlocker {
+public class RecipeUnlockUtil {
 
     public static void unlockRecipesIfRequired() {
         if (BetterRecipeBook.config.newRecipes.unlockAll) {

--- a/common/src/main/resources/assets/brb/lang/en_us.json
+++ b/common/src/main/resources/assets/brb/lang/en_us.json
@@ -23,6 +23,7 @@
 
   "text.autoconfig.brb.category.newRecipes": "New Recipes Settings",
   "text.autoconfig.brb.option.newRecipes.unlockAll": "Automatically unlock all recipes",
+  "text.autoconfig.brb.option.newRecipes.unlockAll.@Tooltip": "Requires world/server re-join to take effect",
   "text.autoconfig.brb.option.newRecipes.enableBounce": "Enable unlock bounce animation",
   "text.autoconfig.brb.option.newRecipes.enableBounce.@Tooltip": "Enable the little bounce animation when you unlock a new item",
 

--- a/common/src/main/resources/assets/brb/lang/en_us.json
+++ b/common/src/main/resources/assets/brb/lang/en_us.json
@@ -32,6 +32,7 @@
   "brb.gui.instantCraft.on": "Instant crafting is on",
   "brb.gui.instantCraft.off": "Instant crafting is off",
   "brb.gui.settings.open": "Open settings",
-
+  "brb.gui.crafting.lockedRecipe": "Craft once to unlock:",
+  "brb.gui.furnace.lockedRecipe": "Smelt once to unlock:",
   "brb.gui.smithable": "Showing Smithable"
 }

--- a/common/src/main/resources/assets/brb/lang/en_us.json
+++ b/common/src/main/resources/assets/brb/lang/en_us.json
@@ -25,8 +25,6 @@
   "text.autoconfig.brb.option.newRecipes.unlockAll": "Automatically unlock all recipes",
   "text.autoconfig.brb.option.newRecipes.enableBounce": "Enable unlock bounce animation",
   "text.autoconfig.brb.option.newRecipes.enableBounce.@Tooltip": "Enable the little bounce animation when you unlock a new item",
-  "text.autoconfig.brb.option.newRecipes.forcePlaceRecipes": "Force place recipes",
-  "text.autoconfig.brb.option.newRecipes.forcePlaceRecipes.@Tooltip": "Manually place a recipe client-side instead of asking the server to do it.\nThis fixes issues where clicking on a recipe might not place, it if you haven't unlocked it yet.\nThis feature doesn't work for batch crafting.",
 
   "brb.gui.pin.add": "Press F to pin this recipe",
   "brb.gui.pin.remove": "Press F to unpin this recipe",

--- a/common/src/main/resources/assets/brb/lang/en_us.json
+++ b/common/src/main/resources/assets/brb/lang/en_us.json
@@ -25,6 +25,8 @@
   "text.autoconfig.brb.option.newRecipes.unlockAll": "Automatically unlock all recipes",
   "text.autoconfig.brb.option.newRecipes.enableBounce": "Enable unlock bounce animation",
   "text.autoconfig.brb.option.newRecipes.enableBounce.@Tooltip": "Enable the little bounce animation when you unlock a new item",
+  "text.autoconfig.brb.option.newRecipes.forcePlaceRecipes": "Force place recipes",
+  "text.autoconfig.brb.option.newRecipes.forcePlaceRecipes.@Tooltip": "Manually place a recipe client-side instead of asking the server to do it.\nThis fixes issues where clicking on a recipe might not place, it if you haven't unlocked it yet.\nThis feature doesn't work for batch crafting.",
 
   "brb.gui.pin.add": "Press F to pin this recipe",
   "brb.gui.pin.remove": "Press F to unpin this recipe",

--- a/common/src/main/resources/mixins.brb-common.json
+++ b/common/src/main/resources/mixins.brb-common.json
@@ -35,7 +35,8 @@
     "ungroup.ClientRecipeBookMixin",
     "ungroup.RecipeBookComponentMixin",
     "unlockrecipes.ClientPacketListenerMixin",
-    "unlockrecipes.MultiPlayerGameModeMixin"
+    "unlockrecipes.MultiPlayerGameModeMixin",
+    "unlockrecipes.RecipeManagerMixin"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
Manually place ingredients in the crafting grid rather than asking the server to do it. (addresses #83)

This fixes issues where the server doesn't properly track unlocked recipes and prevents you from auto-filling recipes you haven't "unlocked" yet.
 
- [ ] ~Add Force place recipes option to New Recipes Settings~
- [X] Implement force place recipes
- [X] Support Instant Crafting
- [ ] ~Support Batch Crafting~
- [x] Automatically detect when server has locked recipe and use force place recipe.