### PR TITLE
Fix Japanese Trasnalation

### DIFF
--- a/common/src/main/resources/assets/brb/lang/ja_jp.json
+++ b/common/src/main/resources/assets/brb/lang/ja_jp.json
@@ -12,7 +12,7 @@
 
   "text.autoconfig.brb.category.instantCraft": "即時クラフト設定",
   "text.autoconfig.brb.option.instantCraft.showButton": "即時クラフト切替えボタンを表示する",
-  "text.autoconfig.brb.option.instantCraft.enabled": "インスタント・クラフト有効",
+  "text.autoconfig.brb.option.instantCraft.enabled": "即時クラフトが有効",
 
   "text.autoconfig.brb.category.scrolling": "頁送り設定",
   "text.autoconfig.brb.option.scrolling.scrollAround": "頁送りを循環させる",


### PR DESCRIPTION
I fixed Japanese translation “インスタント・クラフト” to “即時クラフト.”

The term “instant craft” is uniformaly translated into “即時クラフト” here.

(In addition, Minecraft term such as “Instant Health” is translated into “即時回復.”)